### PR TITLE
http: don't return entries that matched last domain in title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CMakeLists.txt.*
 build/
+.DS_Store

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -182,7 +182,7 @@ bool Service::removeFirstDomain(QString & hostname)
     if (pos < 0)
         return false;
     hostname = hostname.mid(pos + 1);
-    return !hostname.isEmpty();
+    return !hostname.isEmpty() && hostname.indexOf(".") >= 0;
 }
 
 QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)


### PR DESCRIPTION
Fixes wrong behaviour when entry title "http://dropbox.com my pass" matches any request with "com" domain.
